### PR TITLE
Added basic CircleCI build and deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,22 +11,12 @@ jobs:
     steps:
       - checkout
 
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "requirements.txt" }}
-            - v1-dependencies-
-
       - run:
           name: Install dependencies
           command: |
             python3 -m venv venv
             . venv/bin/activate
             pip install -r requirements.txt
-
-      - save_cache:
-          paths:
-            - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
 
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,6 @@ jobs:
             - ./venv
           key: v1-dependencies-{{ checksum "requirements.txt" }}
 
-
       - restore_cache:
           keys:
             - gallery

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,11 @@ jobs:
     steps:
       - checkout
 
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "requirements.txt" }}
+            - v1-dependencies-
+
       - run:
           name: Install dependencies
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,36 @@
+version: 2.1
+
+orbs:
+  aws-cli: circleci/aws-cli@0.1.16
+
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.7.2
+
+    steps:
+      - checkout
+
+      - run:
+          name: install dependencies
+          command: pip install -r requirements.txt
+
+      - run:
+          name: build tutorials
+          command: make html
+
+      - deploy:
+          name: deploy to AWS
+          command: |
+            if [ "${CIRCLE_BRANCH}" = "master" ]; then
+              aws s3 sync _build/html s3://pennylane.ai/qml --delete
+              aws cloudfront create-invalidation --distribution-id EQO2PENH3I2OG --paths /qml/*
+            else
+              echo "Not master branch, dry run only"
+            fi
+
+workflows:
+  workflow:
+    jobs:
+      - build:
+          context: aws_credentials

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,11 +11,6 @@ jobs:
     steps:
       - checkout
 
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "requirements.txt" }}
-            - v1-dependencies-
-
       - run:
           name: Install dependencies
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: pip install -r requirements.txt
+          command: pip install -r requirements.txt --user
 
       - run:
           name: Build tutorials
@@ -24,7 +24,7 @@ jobs:
           command: |
             if [ "${CIRCLE_BRANCH}" = "master" ]; then
               aws s3 sync _build/html s3://pennylane.ai/qml --delete
-              aws cloudfront create-invalidation --distribution-id EQO2PENH3I2OG --paths /qml/*
+              aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths /qml/*
             else
               echo "Not master branch, dry run only"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,15 +12,15 @@ jobs:
       - checkout
 
       - run:
-          name: install dependencies
+          name: Install dependencies
           command: pip install -r requirements.txt
 
       - run:
-          name: build tutorials
+          name: Build tutorials
           command: make html
 
       - deploy:
-          name: deploy to AWS
+          name: Deploy to AWS
           command: |
             if [ "${CIRCLE_BRANCH}" = "master" ]; then
               aws s3 sync _build/html s3://pennylane.ai/qml --delete

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,11 +28,22 @@ jobs:
             - ./venv
           key: v1-dependencies-{{ checksum "requirements.txt" }}
 
+
+      - restore_cache:
+          keys:
+            - gallery
+
       - run:
           name: Build tutorials
           command: |
             . venv/bin/activate
             make html
+
+      - save_cache:
+          paths:
+            - ./tutorial
+            - ./app
+          key: gallery
 
       - deploy:
           name: Deploy to AWS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
 
     steps:
       - checkout
+        path: ~/qml
 
       - run:
           name: Install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,9 @@ jobs:
 
       - run:
           name: Build tutorials
-          command: make html
+          command: |
+            . venv/bin/activate
+            make html
 
       - deploy:
           name: Deploy to AWS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: pip install -r requirements.txt --user
+          command: sudo pip install -r requirements.txt
 
       - run:
           name: Build tutorials

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ jobs:
 
     steps:
       - checkout
-        path: ~/qml
 
       - run:
           name: Install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,22 @@ jobs:
     steps:
       - checkout
 
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "requirements.txt" }}
+            - v1-dependencies-
+
       - run:
           name: Install dependencies
-          command: sudo pip install -r requirements.txt
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -r requirements.txt
+
+      - save_cache:
+          paths:
+            - ./venv
+          key: v1-dependencies-{{ checksum "requirements.txt" }}
 
       - run:
           name: Build tutorials

--- a/conf.py
+++ b/conf.py
@@ -108,7 +108,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "venv"]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,8 @@ pennylane-forest
 pyquil==2.10
 scipy
 sphinx==1.8.5
-sphinxcontrib-bibtex
-sphinx_gallery
+sphinxcontrib-bibtex==0.4.2
+sphinx_gallery==0.3.1
 strawberryfields
 tensorflow==1.13.2
 toml

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ autograd
 numpy
 pygments-github-lexers
 semantic_version==2.6
+git+git://github.com/XanaduAI/pennylane.git#egg=pennylane
 git+git://github.com/XanaduAI/pennylane-sf.git#egg=PennyLane_SF
 pennylane-forest
 pyquil==2.10


### PR DESCRIPTION
**Description of changes:**

* Adds a basic CircleCI script that builds the documentation, deploys to S3, and invalidates cloudfront.

* Currently, deployment only applies to the master branch. PRs will still build, but not deploy.

* Built tutorials (`tutorial/tutorial_*`) and built implementations (`app/tutorial_*`) are restored from cache. If a sourcefile (`beginner/tutorial_*.py` and `implementations/tutorial_*.py`) has changed, Sphinx-Gallery will auto-rebuild it (it compares the md5 hash of the source files against a `tutorial/tutorial_*.rst.md5` file from the restored cache).

**Future questions:**

* How do we temporarily build PRs?

* How do we have CircleCI comment on PRs with (a) links to rendered PR, and (b) any build errors?

**Related GitHub Issues:** n/a
