### PR TITLE
Modifies doubly stochastic tutorial to run on IBM Q

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,8 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "requirements.txt" }}
-            - v1-dependencies-
+            - v2-dependencies-{{ checksum "requirements.txt" }}
+            - v2-dependencies-
 
       - run:
           name: Install dependencies
@@ -34,7 +34,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
+          key: v2-dependencies-{{ checksum "requirements.txt" }}
 
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,11 @@ jobs:
       - aws-cli/setup:
           aws-region: AWS_REGION
 
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "requirements.txt" }}
+            - v1-dependencies-
+
       - run:
           name: Install dependencies
           command: |
@@ -25,6 +30,11 @@ jobs:
             . venv/bin/activate
             pip install pip setuptools --upgrade
             pip install -r requirements.txt
+
+      - save_cache:
+          paths:
+            - ./venv
+          key: v1-dependencies-{{ checksum "requirements.txt" }}
 
       - restore_cache:
           keys:

--- a/implementations/tutorial_doubly_stochastic.py
+++ b/implementations/tutorial_doubly_stochastic.py
@@ -1,6 +1,6 @@
 r"""
-Doubly stochastic gradient descent
-==================================
+Doubly stochastic gradient descent on IBM Q
+===========================================
 
 In this tutorial we investigate and implement the doubly stochastic gradient descent
 paper from `Ryan Sweke et al. (2019) <https://arxiv.org/abs/1910.01155>`__. In this paper,
@@ -256,7 +256,10 @@ print("Stochastic gradient descent (shots=1) min energy = ", qnode_analytic(para
 # convergence continues to be guaranteed!
 #
 # Let's create a QNode that randomly samples a single term from the above
-# Hamiltonian as the observable to be measured.
+# Hamiltonian as the observable to be measured. This time, we will run
+# the example using IBM Q quantum hardware.
+
+dev_stochastic = qml.device("qiskit.ibmq", wires=2, backend="ibmqx2", shots=100)
 
 I = np.identity(2)
 X = np.array([[0, 1], [1, 0]])

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ semantic_version==2.6
 pennylane
 pennylane-sf
 pennylane-forest
+pennylane-qiskit
 pyquil==2.10
 scipy
 sphinx==1.8.5


### PR DESCRIPTION
A modification of the doubly stochastic tutorial to run on IBM Q ibmqx2.

Note: depending on queue wait time, this currently takes too long on CircleCI to complete.