### PR TITLE
Bugfix for the barren plateau tutorial

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,8 @@ orbs:
 
 jobs:
   build:
-    executor:
-      name: aws-cli/default
-      python-version: '3.7.2'
+    docker:
+      - image: circleci/python:3.7.2
 
     steps:
       - checkout
@@ -36,36 +35,60 @@ jobs:
             - ./app
           key: gallery
 
-      - persist_to_workspace:
-          root: $CIRCLE_WORKING_DIRECTORY
-
   deploy:
     executor:
       name: aws-cli/default
       python-version: '3.7.2'
 
+    docker:
+      - image: circleci/python:3.7.2
+
     steps:
+      - checkout
+
       - aws-cli/setup:
           aws-region: AWS_REGION
 
-      - attach_workspace:
-          at: $CIRCLE_WORKING_DIRECTORY
+      - run:
+          name: Install dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install pip setuptools --upgrade
+            pip install -r requirements.txt
+
+      - restore_cache:
+          keys:
+            - gallery
+
+      - run:
+          name: Build tutorials
+          command: |
+            . venv/bin/activate
+            make html
+
+      - save_cache:
+          paths:
+            - ./tutorial
+            - ./app
+          key: gallery
 
       - deploy:
           name: Deploy to AWS
           command: |
-              aws s3 sync _build/html s3://pennylane.ai/qml --delete
-              aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths /qml/*
+            aws s3 sync _build/html s3://pennylane.ai/qml --delete
+            aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths /qml/*
 
 workflows:
-  build_and_deploy:
-      jobs:
-        - build
-        - deploy:
-          context: aws_credentials
-          requires:
-            - build
+  workflow:
+    jobs:
+      - build:
           filters:
             branches:
-              only:
-                - master
+              ignore: master
+
+      - deploy:
+          context: aws_credentials
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ workflows:
   build_and_deploy:
       jobs:
         - build
-        - deploy
+        - deploy:
           context: aws_credentials
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,14 +9,8 @@ jobs:
       name: aws-cli/default
       python-version: '3.7.2'
 
-    docker:
-      - image: circleci/python:3.7.2
-
     steps:
       - checkout
-
-      - aws-cli/setup:
-          aws-region: AWS_REGION
 
       - run:
           name: Install dependencies
@@ -42,18 +36,36 @@ jobs:
             - ./app
           key: gallery
 
+      - persist_to_workspace:
+          root: $CIRCLE_WORKING_DIRECTORY
+
+  deploy:
+    executor:
+      name: aws-cli/default
+      python-version: '3.7.2'
+
+    steps:
+      - aws-cli/setup:
+          aws-region: AWS_REGION
+
+      - attach_workspace:
+          at: $CIRCLE_WORKING_DIRECTORY
+
       - deploy:
           name: Deploy to AWS
           command: |
-            if [ "${CIRCLE_BRANCH}" = "master" ]; then
               aws s3 sync _build/html s3://pennylane.ai/qml --delete
               aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths /qml/*
-            else
-              echo "Not master branch, dry run only"
-            fi
 
 workflows:
-  workflow:
-    jobs:
-      - build:
+  build_and_deploy:
+      jobs:
+        - build
+        - deploy
           context: aws_credentials
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - master

--- a/implementations/tutorial_barren_plateaus.py
+++ b/implementations/tutorial_barren_plateaus.py
@@ -115,8 +115,8 @@ def rand_circuit(params, random_gate_sequence=None, num_qubits=None):
 # While we only sample 200 random circuits to allow the code
 # to run in a reasonable amount of time, this can be
 # increased for more accurate results. We only consider the
-# gradient of the output wr.t. to the last parameter in the
-# circuit. Hence we choose to save gradient[-1] only.
+# gradient of the output with respect to the last parameter in the
+# circuit. Hence we choose to save ``gradient[-1]`` only.
 
 grad_vals = []
 num_samples = 200

--- a/implementations/tutorial_barren_plateaus.py
+++ b/implementations/tutorial_barren_plateaus.py
@@ -73,7 +73,7 @@ from pennylane import numpy as np
 import matplotlib.pyplot as plt
 
 
-##################################################
+##############################################################################
 # Next, we create a randomized variational circuit
 
 # Set a seed for reproducibility
@@ -110,7 +110,7 @@ def rand_circuit(params, random_gate_sequence=None, num_qubits=None):
     return qml.expval(qml.Hermitian(H, wirelist))
 
 
-############################################################
+##############################################################################
 # Now we can compute the gradient and calculate the variance.
 # While we only sample 200 random circuits to allow the code
 # to run in a reasonable amount of time, this can be
@@ -133,11 +133,10 @@ print("Variance of the gradients for {} random circuits: {}".format(num_samples,
 print("Mean of the gradients for {} random circuits: {}".format(num_samples, np.mean(grad_vals)))
 
 
-###########################################################
+##############################################################################
 # Evaluate the gradient for more qubits
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# We can repeat the above analysis with increasing number
-# of qubits.
+# We can repeat the above analysis with increasing number of qubits.
 
 
 qubits = [2, 3, 4, 5, 6]

--- a/implementations/tutorial_barren_plateaus.py
+++ b/implementations/tutorial_barren_plateaus.py
@@ -77,12 +77,11 @@ import matplotlib.pyplot as plt
 # Next, we create a randomized variational circuit
 
 # Set a seed for reproducibility
-np.random.seed(20)
+np.random.seed(42)
 
 num_qubits = 4
 dev = qml.device("default.qubit", wires=num_qubits)
 gate_set = [qml.RX, qml.RY, qml.RZ]
-gate_sequence = {i: np.random.choice(gate_set) for i in range(num_qubits)}
 
 
 def rand_circuit(params, random_gate_sequence=None, num_qubits=None):
@@ -113,21 +112,25 @@ def rand_circuit(params, random_gate_sequence=None, num_qubits=None):
 
 ############################################################
 # Now we can compute the gradient and calculate the variance.
-# While we only take 200 samples to allow the code to run in
-# a reasonable amount of time, this can be increased
-# for more accurate results.
+# While we only sample 200 random circuits to allow the code
+# to run in a reasonable amount of time, this can be
+# increased for more accurate results. We only consider the
+# gradient of the output wr.t. to the last parameter in the
+# circuit. Hence we choose to save gradient[-1] only.
 
-qcircuit = qml.QNode(rand_circuit, dev)
-grad = qml.grad(qcircuit, argnum=0)
-
-num_samples = 200
 grad_vals = []
+num_samples = 200
 
 for i in range(num_samples):
+    gate_sequence = {i: np.random.choice(gate_set) for i in range(num_qubits)}
+    qcircuit = qml.QNode(rand_circuit, dev)
+    grad = qml.grad(qcircuit, argnum=0)
     params = np.random.uniform(0, 2 * np.pi, size=num_qubits)
-    grad_vals.append(grad(params, random_gate_sequence=gate_sequence, num_qubits=num_qubits))
+    gradient = grad(params, random_gate_sequence=gate_sequence, num_qubits=num_qubits)
+    grad_vals.append(gradient[-1])
 
-print("Variance of the gradient for {} samples: {}".format(num_samples, np.var(grad_vals)))
+print("Variance of the gradients for {} random circuits: {}".format(num_samples, np.var(grad_vals)))
+print("Mean of the gradients for {} random circuits: {}".format(num_samples, np.mean(grad_vals)))
 
 
 ###########################################################
@@ -137,38 +140,24 @@ print("Variance of the gradient for {} samples: {}".format(num_samples, np.var(g
 # of qubits.
 
 
-def generate_random_circuit(num_qubits):
-    """
-    Generates a random quantum circuit based on (McClean et. al., 2019).
-
-    Args:
-        num_qubits (int): the number of qubits in the circuit
-    """
-    dev = qml.device("default.qubit", wires=num_qubits)
-    gate_set = [qml.RX, qml.RY, qml.RZ]
-    random_gate_sequence = {i: np.random.choice(gate_set) for i in range(num_qubits)}
-    qcircuit = qml.QNode(rand_circuit, dev)
-
-    return qcircuit, random_gate_sequence
-
-
 qubits = [2, 3, 4, 5, 6]
 variances = []
 
-num_samples = 200
-
 
 for num_qubits in qubits:
-    qcircuit, gate_sequence = generate_random_circuit(num_qubits)
-    grad = qml.grad(qcircuit, argnum=0)
     grad_vals = []
     for i in range(num_samples):
-        params = np.random.uniform(0, 2 * np.pi, size=num_qubits)
-        grad_vals.append(grad(params, random_gate_sequence=gate_sequence, num_qubits=num_qubits))
-    vargrad = np.var(grad_vals)
-    variances.append(vargrad)
-    print("Variance of the gradient for {} qubits: {}".format(num_qubits, vargrad))
+        dev = qml.device("default.qubit", wires=num_qubits)
+        qcircuit = qml.QNode(rand_circuit, dev)
+        grad = qml.grad(qcircuit, argnum=0)
 
+        gate_set = [qml.RX, qml.RY, qml.RZ]
+        random_gate_sequence = {i: np.random.choice(gate_set) for i in range(num_qubits)}
+
+        params = np.random.uniform(0, np.pi, size=num_qubits)
+        gradient = grad(params, random_gate_sequence=random_gate_sequence, num_qubits=num_qubits)
+        grad_vals.append(gradient[-1])
+    variances.append(np.var(grad_vals))
 
 variances = np.array(variances)
 qubits = np.array(qubits)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ networkx==2.3
 pygments-github-lexers
 semantic_version==2.6
 git+git://github.com/XanaduAI/strawberryfields#egg=strawberryfields
+pip==19.2
 protobuf==3.8.0
 pennylane
 pennylane-sf


### PR DESCRIPTION
**Bug fix for the barren plateau tutorial**


**Summary:**
This updates the PennyLane tutorial on the Barren Plateau paper by McClean et. al., 2018. I had misunderstood the calculation of the gradient value before by thinking that we are looking at the variance of the gradients for the same weight. However, the variance of the gradient is for the entire circuit at a time by choosing a random sequence of unitary and a random parameter value as mentioned in the caption of Figure 2 in the paper.

We loop over 200 different random sequences of gates and each time choose a random parameter value to evaluate the gradients. Then we only consider a particular weight to store the gradient (i.e., gradient[-1] and then take the variance of all the gradients from the 200 different circuits.

Reproduces the correct plot from the paper: