### PR TITLE
Port state preparation tutorial to use PL-Qiskit

### DIFF
--- a/implementations/tutorial_state_preparation.py
+++ b/implementations/tutorial_state_preparation.py
@@ -1,15 +1,15 @@
 r"""
 .. _state_preparation:
 
-State preparation with Rigetti Forest + PyTorch
-===============================================
+State preparation with Qiskit + PyTorch
+=======================================
 
 In this notebook, we build and optimize a circuit to prepare arbitrary
 single-qubit states, including mixed states. Along the way, we also show
 how to:
 
 1. Construct compact expressions for circuits composed of many layers.
-2. Succintly evaluate expectation values of many observables.
+2. Succinctly evaluate expectation values of many observables.
 3. Estimate expectation values from repeated measurements, as in real
    hardware.
 """
@@ -95,14 +95,10 @@ def layer(params, j):
 
 ##############################################################################
 # To set up the device, we select a plugin that is compatible with
-# evaluating expectations through sampling: the ``forest.qvm`` plugin. The
-# syntax is slightly different than for other plugins, we need to also
-# feed a ``device`` keyword specifying the number of qubits in the format
-# ``[number of qubits]q-pyqvm``. The keyword ``shots`` indicates the
-# number of samples used to estimate expectation values.
-#
+# evaluating expectations through sampling: the ``qiskit.aer`` plugin. The keyword ``shots``
+# indicates the number of samples used to estimate expectation values.
 
-dev = qml.device("forest.qvm", device="3q-pyqvm", shots=1000)
+dev = qml.device('qiskit.aer', wires=3, shots=1000)
 
 ##############################################################################
 # When defining the QNode, we introduce as input a Hermitian operator

--- a/implementations/tutorial_state_preparation.py
+++ b/implementations/tutorial_state_preparation.py
@@ -145,7 +145,7 @@ def cost_fn(params):
 opt = torch.optim.Adam([params], lr=0.1)
 
 # number of steps in the optimization routine
-steps = 200
+steps = 100
 
 # the final stage of optimization isn't always the best, so we keep track of
 # the best parameters along the way

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,10 +13,8 @@ protobuf==3.8.0
 pennylane==0.8.0
 pennylane-qchem==0.8.0
 pennylane-sf==0.8.0
--e git://github.com/rigetti/pennylane-forest.git#egg=pennylane-forest
 pennylane-cirq==0.8.0
 pennylane-qiskit==0.8.0
-pyquil==2.10
 scipy==1.3.2
 sphinx==1.8.5
 sphinxcontrib-bibtex==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ pennylane-qchem==0.8.0
 pennylane-sf==0.8.0
 -e git://github.com/rigetti/pennylane-forest.git#egg=pennylane-forest
 pennylane-cirq==0.8.0
+pennylane-qiskit==0.8.0
 pyquil==2.10
 scipy==1.3.2
 sphinx==1.8.5


### PR DESCRIPTION
**Summary**

Port the state preparation tutorial from using PL-Forest to using PL-Qiskit. This fixes https://github.com/XanaduAI/qml/issues/35.

**Benefits**

- This tutorial can be a major bottleneck in building the documentation when using later versions of pyquil - it can take on the order of days. Currently we have `pyquil` pinned to `v2.10` in the requirements, which is now relatively outdated as the latest release is `v2.17`. This PR will remove the dependency on pyquil and ensure that users don't have to wait a long time to build the docs.
- We currently do not have a tutorial showing the use of Qiskit, this PR will add this.

**Possible drawbacks**

- We would no longer have example use of Forest in the tutorials. However, there are incoming tutorials (e.g. https://github.com/XanaduAI/qml/pull/37) that will add this back in and be compatible with later releases of pyquil.
- The original `pyqvm` Rigetti device was very fast and typically could do 10 iterations in about 4 seconds on my PC (total time = 1-2 mins). Switching to `qiskit.aer` is much slower, 10 iterations is about 40 seconds (total time = 10-15 mins).
- I have had to decrease the number of steps from 200 to 100 to prevent timeout on CircleCI (halving the runtimes above). Actually, things seem ok in just 100 steps although the cost function is quite variable.