### PR TITLE
Port state preparation tutorial to use default.qubit

### DIFF
--- a/implementations.rst
+++ b/implementations.rst
@@ -10,7 +10,7 @@ algorithms using PennyLane and near-term quantum hardware.
 :html:`<div class="gallery-grid row">`
 
 .. customgalleryitem::
-    :tooltip: Do arbitrary state preparation on a real quantum computer.
+    :tooltip: Learn to prepare arbitrary states.
     :figure: implementations/state_preparation/NOON.png
     :description: :doc:`app/tutorial_state_preparation`
 

--- a/implementations/tutorial_state_preparation.py
+++ b/implementations/tutorial_state_preparation.py
@@ -1,15 +1,15 @@
 r"""
 .. _state_preparation:
 
-State preparation with Rigetti Forest + PyTorch
-===============================================
+State preparation with PyTorch
+==============================
 
 In this notebook, we build and optimize a circuit to prepare arbitrary
 single-qubit states, including mixed states. Along the way, we also show
 how to:
 
 1. Construct compact expressions for circuits composed of many layers.
-2. Succintly evaluate expectation values of many observables.
+2. Succinctly evaluate expectation values of many observables.
 3. Estimate expectation values from repeated measurements, as in real
    hardware.
 """
@@ -94,15 +94,9 @@ def layer(params, j):
 
 
 ##############################################################################
-# To set up the device, we select a plugin that is compatible with
-# evaluating expectations through sampling: the ``forest.qvm`` plugin. The
-# syntax is slightly different than for other plugins, we need to also
-# feed a ``device`` keyword specifying the number of qubits in the format
-# ``[number of qubits]q-pyqvm``. The keyword ``shots`` indicates the
-# number of samples used to estimate expectation values.
-#
+# We use the ``default.qubit`` device.
 
-dev = qml.device("forest.qvm", device="3q-pyqvm", shots=1000)
+dev = qml.device("default.qubit", wires=3)
 
 ##############################################################################
 # When defining the QNode, we introduce as input a Hermitian operator

--- a/implementations/tutorial_state_preparation.py
+++ b/implementations/tutorial_state_preparation.py
@@ -94,7 +94,8 @@ def layer(params, j):
 
 
 ##############################################################################
-# We use the ``default.qubit`` device.
+# Here, we use the ``default.qubit`` device to perform the optimization, but this can be changed to
+# any other supported device.
 
 dev = qml.device("default.qubit", wires=3)
 


### PR DESCRIPTION
**Summary**

Port the state preparation tutorial from using PL-Forest to using `default.qubit` This fixes https://github.com/XanaduAI/qml/issues/35.

**Benefits**

- This tutorial can be a major bottleneck in building the documentation when using later versions of pyquil - it can take on the order of days. Currently we have `pyquil` pinned to `v2.10` in the requirements, which is now relatively outdated as the latest release is `v2.17`. This PR means that none of the tutorials will use PL-Forest, and we can update to pyquil `v2.17` when required without having issues with build time.

**Possible drawbacks**

- We would no longer have example use of Forest in the tutorials. However, there are incoming tutorials (e.g. https://github.com/XanaduAI/qml/pull/37 and https://github.com/XanaduAI/qml/pull/40) that will add this back in and be compatible with later releases of pyquil.

This closes https://github.com/XanaduAI/qml/pull/39. We tried to port to PL-Qiskit, but the build time was still a bit too slow.