### PR TITLE
Change "i" in epoch iteration in training phase to "j"

### DIFF
--- a/implementations/tutorial_embeddings_metric_learning.py
+++ b/implementations/tutorial_embeddings_metric_learning.py
@@ -313,7 +313,7 @@ optimizer = qml.RMSPropOptimizer(stepsize=0.01)
 batch_size = 5
 pars = init_pars
 
-for i in range(2):
+for j in range(2):
 
     # Sample a batch of training inputs from each class
     selectA = np.random.choice(range(len(A)), size=(batch_size,), replace=True)
@@ -323,10 +323,10 @@ for i in range(2):
 
     # Walk one optimization step
     pars = optimizer.step(lambda w: cost(w, A=A_batch, B=B_batch), pars)
-    print("Step", i, "done.")
+    print("Step", j, "done.")
 
     # Print the validation cost every 10 steps
-    if i % 5 == 0 and i != 0:
+    if j % 5 == 0 and j != 0:
         cst = cost(pars, A=A_val, B=B_val)
         print("Cost on validation set {:2f}".format(cst))
 


### PR DESCRIPTION
Using "i" for iterating epochs in the training phase seems to lead to an error in the ising_hamiltonian function when you have a range greater than 2 due to the ising_hamiltonian function also using the variable i. Easy fix for this is to change the epoch iteration to "j"

### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] Ensure that your tutorial executes correctly, and conforms to the
      guidelines specified in the [README](../README.md).

- [ ] Add a thumbnail link to your tutorial in `beginner.rst`, or if a
      QML implementation, in `implementations.rst`.

- [ ] All QML tutorials conform to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      To auto format files, simply `pip install black`, and then
      run `black -l 100 path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Title:**

**Summary:**

**Relevant references:**

**Possible Drawbacks:**

**Related GitHub Issues:**
