### PR TITLE
Change ising_hamiltonian function to only use l

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
           name: Comment artifacts
           command: |
             if [ -z "$GH_AUTH_TOKEN" ]; then
-              echo "No credentials available, artifacts will not be commented.""
+              echo "No credentials available, artifacts will not be commented."
             else
               echo "Credentials are available. Commenting artifacts to GitHub PR..."
               pip3 install pygithub --user && python3 .circleci/comment.py

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,13 @@ jobs:
 
       - run:
           name: Comment artifacts
-          command: pip3 install pygithub --user && python3 .circleci/comment.py
+          command: |
+            if [ -z "$GH_AUTH_TOKEN" ]; then
+              echo "No credentials available, artifacts will not be commented.""
+            else
+              echo "Credentials are available. Commenting artifacts to GitHub PR..."
+              pip3 install pygithub --user && python3 .circleci/comment.py
+            fi
 
   deploy:
     executor:

--- a/implementations/tutorial_embeddings_metric_learning.py
+++ b/implementations/tutorial_embeddings_metric_learning.py
@@ -122,7 +122,7 @@ def ising_hamiltonian(weights, wires, l):
         CNOT(wires=wires)
         # local fields
         for w in wires:
-            RY(weights[l, i + 1], wires=w)
+            RY(weights[l, l - 1], wires=w)
 
 def QAOAEmbedding(features, weights, wires):
 


### PR DESCRIPTION
There is a bug in the ising_hamiltonian function. It works in the tutorial as long as you use a range in the training phase of 2 but when you changed this to 3 or more it would raise an exception. I believe this is due to the fact that the training epoch iterator is "i" and for some reason the ising_hamiltonian function also used "i" even though I don't believe that is should (or has to). The q_weights passed to it are size (4,3) so I believe the better way to do this would be to use "RY(weights[l, l-1], wires=w)"