### PR TITLE
Fix PennyLane link bug

### DIFF
--- a/xanadu_theme/layout.html
+++ b/xanadu_theme/layout.html
@@ -190,7 +190,7 @@
     <!-- Nanoscroller -->
     <script type="text/javascript" src="{{ pathto('_static/js/nanoscroller.min.js', 1) }}"></script>
     <script type="text/javascript">
-        $('a.reference.internal').each(function(){
+        $('a.reference.external').each(function(){
           var link = $(this).attr("href");
           var hash = link.split('#')[1];
           var page = link.split('#')[0].split('/').slice(-1)[0].replace(".html", "");


### PR DESCRIPTION
This fixes a bug where links to, e.g., classes, modules, functions from the PL repo resulted in loading halfway down the page.

Currently:
![image](https://user-images.githubusercontent.com/49409390/74758109-e31ffe80-5244-11ea-997a-f74f512d3681.png)

With fix:
![image (1)](https://user-images.githubusercontent.com/49409390/74758126-e7e4b280-5244-11ea-8725-d2b2343e04b1.png)

(Continues from this commit: https://github.com/XanaduAI/qml/pull/37/commits/926c0683bc32fcfd00530c090a7ed739653e545b)