### PR TITLE
Add structured data to "What is QML" page

### DIFF
--- a/xanadu_theme/layout.html
+++ b/xanadu_theme/layout.html
@@ -163,6 +163,10 @@
             </div>
           </div>
           {%- block comments -%}
+
+            {% if pagename == "whatisqml" %}
+                {% include "whatisqml_structured.html" %}
+            {% endif %}
             {% if pagename == "demonstrations" %}
               {% include "filters.html" %}
               <style>

--- a/xanadu_theme/layout.html
+++ b/xanadu_theme/layout.html
@@ -97,6 +97,9 @@
   {%- endblock %}
 
   <title>{{ title|striptags|e }} &#8212; PennyLane</title>
+  {% if pagename == "whatisqml" %}
+    {% include "whatisqml_structured.html" %}
+  {% endif %}
 {%- endblock %}
 
 {# Displays the next and previous links both before and after content #}
@@ -164,9 +167,6 @@
           </div>
           {%- block comments -%}
 
-            {% if pagename == "whatisqml" %}
-                {% include "whatisqml_structured.html" %}
-            {% endif %}
             {% if pagename == "demonstrations" %}
               {% include "filters.html" %}
               <style>

--- a/xanadu_theme/whatisqml_structured.html
+++ b/xanadu_theme/whatisqml_structured.html
@@ -1,0 +1,24 @@
+<script type="application/ld+json">
+    {
+    "@context": "http://schema.org/",
+    "@type": "Article",
+    "author": {
+        "@type": "Organization",
+        "name": "Xanadu"
+    },
+    "datePublished": "2019-01-01",
+    "headline": "What is QML?",
+    "image": "_static/gpu_to_qpu.png",
+    "publisher": {
+    "@type": "Organization",
+    "name": "Xanadu",
+    "logo": {
+        "@type": "ImageObject",
+        "url": "_static/xanadu.png"
+        }
+    },
+    "dateModified": "2020-03-01",
+    "description": "Find out how the principles of quantum computing and machine learning can be united to create something new.",
+    "mainEntityOfPage": "https://pennylane.ai/qml/whatisqml.html"
+    }
+</script>


### PR DESCRIPTION
**Summary:**

Adds structured data block to the ``layout.html`` style file, which automatically inserts the block into the ``whatisqml.html`` page.

The result has been tested at Google's online tool.
